### PR TITLE
Child context

### DIFF
--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -129,9 +129,11 @@ export default class ContextManager {
     async getChildrenContent(fileCache:any) {
         let children:any=[];
         const links = fileCache?.links?.filter(e=>e.original.substr(0,2)==="[[");
-        if(links){
-            for (let i = 0; i < links.length; i++) {
-                const link=links[i];
+        //remove duplicates from links
+        const uniqueLinks = links?.filter((v,i,a)=>a.findIndex(t=>(t.link === v.link))===i);
+        if(uniqueLinks){
+            for (let i = 0; i < uniqueLinks.length; i++) {
+                const link=uniqueLinks[i];
                 const path=link.link+".md";
                 let file
                 if (path.includes('/')) {

--- a/src/ContextManager.ts
+++ b/src/ContextManager.ts
@@ -127,6 +127,7 @@ export default class ContextManager {
     }
 
     async getChildrenContent(fileCache:any) {
+        const contextOptions:Context = this.plugin.settings.context;
         let children:any=[];
         const links = fileCache?.links?.filter(e=>e.original.substr(0,2)==="[[");
         //remove duplicates from links
@@ -143,8 +144,18 @@ export default class ContextManager {
                 }
 
                 if (file) {
+                    //load the file
                     const content= await this.app.vault.read(file);
-                    children.push({...file,content});
+
+                    let metadata = this.getMetaData(file.path);
+
+                    //only include frontmatter and headings if the option is set
+                    let blocks:any ={};
+                    if(contextOptions.includeFrontmatter) blocks["frontmatter"] = metadata?.frontmatter;
+
+                    if(contextOptions.includeHeadings) blocks["headings"]= metadata?.headings;
+
+                    children.push({...file,content,...blocks});
                 }
             }
         }

--- a/src/ui/settingsPage.ts
+++ b/src/ui/settingsPage.ts
@@ -93,7 +93,7 @@ export default class TextGeneratorSettingTab extends PluginSettingTab {
 			})
 			.addButton((btn) =>
         btn
-          .setButtonText("Update modeles")
+          .setButtonText("Update models")
           .setCta()
           .onClick(async() => {
 		  if(this.plugin.settings.api_key.length > 0) {


### PR DESCRIPTION
Enables to use the frontmatter of child pages in a template.
I used this to first use a template to summarize my notes:
```---
type: Settlement
sum: 
  - Located in the south of the Silent River 
  - Mostly composed of artisans 
  - Constructed on a cliff with a castle on top of it
  - Relatively Wealthy citizens and good economy 
  - Neutral stance in war and no strategic point of interest  
  - Ruled by Lord Ander, who is supportive of the arts  
  - Majority human population with some other races also present  
  - Militia to defend the city and its inhabitants  
---
```
And then use a template that only uses the Summary for guiding GPT-3 on Context:
```
---
PromptInfo:
 id: expand_description
 name: 🧙 expand the lore
 description: 
 author: Philip
---

Additional information for Context
(DONT INCLUDE INTO PROMPT! THIS IS JUST CONTEXT!):
{{title}} ({{type}}): 
{{#each sum}}
-  {{this}}
{{/each}}
{{#each children}}
{{this.basename}}:
{{#each frontmatter.sum}}
-  {{this}}
{{/each}}

{{/each}}
The above text is just lore information, use it for context on how characters behave or facts about citys to build uppon, but dont reitterate the bullet points.

prompt:
Write new Lore in the style of J. R. R. Tolkien:
{{selection}}
```

This leads to much better Prompts, since you can efficiently give more compact Information about your subject. 