### PR TITLE
Block quote output setting 

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -26,6 +26,7 @@ const DEFAULT_SETTINGS: TextGeneratorSettings = {
 	frequency_penalty: 0.5,
 	prompt: "",
 	showStatusBar: true,
+	outputToBlockQuote: false,
 	promptsPath:"textgenerator/prompts",
 	context:{
 		includeTitle:false,

--- a/src/textGenerator.ts
+++ b/src/textGenerator.ts
@@ -255,6 +255,15 @@ const promptInfo=
                 cursor= editor.listSelections()[0].anchor;
             }
         } 
+
+        if(this.plugin.settings.outputToBlockQuote){
+            let lines = text.split("\n");
+            for (let i = 2; i < lines.length; i++) {
+            lines[i] = "> " + lines[i];
+            }
+            text = lines.join("\n");
+        }
+
         editor.replaceRange(text, cursor);
         editor.setCursor(editor.getCursor());
         logger("insertGeneratedText end");

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ type TextGeneratorSettings= {
   promptsPath: string;
 	showStatusBar: boolean;
   displayErrorInEditor: boolean;
+  outputToBlockQuote: boolean;
   models: any;
   context:Context;
   options:

--- a/src/ui/settingsPage.ts
+++ b/src/ui/settingsPage.ts
@@ -137,6 +137,16 @@ export default class TextGeneratorSettingTab extends PluginSettingTab {
 					this.plugin.settings.displayErrorInEditor = value;
 					await this.plugin.saveSettings();
 				}));
+
+		new Setting(containerEl)
+			.setName('Output generated text to blockquote')
+			.setDesc('Distinguish between AI generated text and typed text using a blockquote')
+			.addToggle(v => v
+				.setValue(this.plugin.settings.outputToBlockQuote)
+				.onChange(async (value) => {
+					this.plugin.settings.outputToBlockQuote = value;
+					await this.plugin.saveSettings();
+				}));
 					
 		containerEl.createEl('H2', {
 				text: 'Prompt parameters (completions)'

--- a/src/ui/settingsPage.ts
+++ b/src/ui/settingsPage.ts
@@ -137,16 +137,6 @@ export default class TextGeneratorSettingTab extends PluginSettingTab {
 					this.plugin.settings.displayErrorInEditor = value;
 					await this.plugin.saveSettings();
 				}));
-
-		new Setting(containerEl)
-			.setName('Output generated text to blockquote')
-			.setDesc('Distinguish between AI generated text and typed text using a blockquote')
-			.addToggle(v => v
-				.setValue(this.plugin.settings.outputToBlockQuote)
-				.onChange(async (value) => {
-					this.plugin.settings.outputToBlockQuote = value;
-					await this.plugin.saveSettings();
-				}));
 					
 		containerEl.createEl('H2', {
 				text: 'Prompt parameters (completions)'
@@ -194,6 +184,7 @@ export default class TextGeneratorSettingTab extends PluginSettingTab {
 		containerEl.createEl('H3', {
 					text: 'General'
 				});	
+
 		new Setting(containerEl)
 			.setName('Show Status in  StatusBar')
 			.setDesc('Show information in the Status Bar')
@@ -201,6 +192,16 @@ export default class TextGeneratorSettingTab extends PluginSettingTab {
 				.setValue(this.plugin.settings.showStatusBar)
 				.onChange(async (value) => {
 					this.plugin.settings.showStatusBar = value;
+					await this.plugin.saveSettings();
+				}));
+
+		new Setting(containerEl)
+			.setName('Output generated text to blockquote')
+			.setDesc('Distinguish between AI generated text and typed text using a blockquote')
+			.addToggle(v => v
+				.setValue(this.plugin.settings.outputToBlockQuote)
+				.onChange(async (value) => {
+					this.plugin.settings.outputToBlockQuote = value;
 					await this.plugin.saveSettings();
 				}));
 


### PR DESCRIPTION
Adds an optional setting (defaults to off) to output the generated text to a markdown blockquote. 

This feature has been helpful in my Obsidian workflow for distinguishing which portions of my notes are written by me versus by the AI. Perhaps others will find this feature useful as well :)