### PR TITLE
handle endpoint special cases

### DIFF
--- a/src/api-request-formatter.ts
+++ b/src/api-request-formatter.ts
@@ -34,12 +34,12 @@ export default class ReqFormatter {
 			frequency_penalty: params.frequency_penalty,
 		};
 
-		let reqUrl = `${params.endpoint}/v1/completions`;
+		let reqUrl = new URL(`/v1/completions`, params.endpoint).href;
 		let reqExtractResult = "requestResults?.choices[0].text";
 
 		const chatModels = ["gpt-3.5-turbo", "gpt-3.5-turbo-0301", "gpt-4"];
 		if (params.engine && chatModels.includes(params.engine)) {
-			reqUrl = `${params.endpoint}/v1/chat/completions`;
+			reqUrl = new URL(`/v1/chat/completions`, params.endpoint).href;
 			reqExtractResult = "requestResults?.choices[0].message.content";
 			bodyParams["messages"] = [{ role: "user", content: params.prompt }];
 		} else {

--- a/src/extractors/audio-extractor.ts
+++ b/src/extractors/audio-extractor.ts
@@ -69,7 +69,7 @@ export default class AudioExtractor implements Extractor<TAbstractFile> {
 		const formData = this.createFormData(audioBuffer, filetype);
 		this.plugin.startProcessing(false);
 		const response = await fetch(
-			`${this.plugin.settings.endpoint}/v1/audio/transcriptions`,
+			new URL("/v1/audio/transcriptions", this.plugin.settings.endpoint).href,
 			{
 				method: "POST",
 				headers: {

--- a/src/ui/settings/settings-page.ts
+++ b/src/ui/settings/settings-page.ts
@@ -161,7 +161,7 @@ export default class TextGeneratorSettingTab extends PluginSettingTab {
 					.onClick(async () => {
 						if (this.plugin.settings.api_key.length > 0) {
 							let reqParams = {
-								url: `${this.plugin.settings.endpoint}/v1/models`,
+								url: new URL("/v1/models", this.plugin.settings.endpoint).href,
 								method: "GET",
 								body: "",
 								headers: {


### PR DESCRIPTION
endpoint input
it will handle these special cases:
- `https://api.openai.com/` (it wont normally work because of the slash at the end)
- `https://api.openai.com/whatever/whatever` (it wont normally work because of the included pathname)