### PR TITLE
Fixes staredBlocks typo

### DIFF
--- a/src/context-manager.ts
+++ b/src/context-manager.ts
@@ -676,13 +676,13 @@ export default class ContextManager {
   async getStarredBlocks(path = "") {
     const fileCache = this.getMetaData(path);
     let content = "";
-    const staredHeadings = fileCache?.headings?.filter(
+    const starredHeadings = fileCache?.headings?.filter(
       (e: { heading: string }) =>
         e.heading.substring(e.heading.length - 1) === "*"
     );
-    if (staredHeadings) {
-      for (let i = 0; i < staredHeadings.length; i++) {
-        content += await this.getTextBloc(staredHeadings[i].heading);
+    if (starredHeadings) {
+      for (let i = 0; i < starredHeadings.length; i++) {
+        content += await this.getTextBloc(starredHeadings[i].heading);
       }
     }
     return content;

--- a/src/ui/settings/sections/considered-context.tsx
+++ b/src/ui/settings/sections/considered-context.tsx
@@ -11,7 +11,7 @@ const contextVariables: string[] = [
   "title",
   "content",
   "selection",
-  "staredBlocks",
+  "starredBlocks",
 ];
 
 const extendedInfo: Record<


### PR DESCRIPTION
Fixes typo that shows up in the settings for the `starredBlocks` template variable