### PR TITLE
Better template sugestion

### DIFF
--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -84,15 +84,13 @@ export class ExampleModal extends FuzzySuggestModal<PromptTemplate> {
   }
 
   getItemText(template: PromptTemplate): string {
-    return (
-      template.tags +
-      ((!template.name || !template.id) ? template.path || "" : "") +
-      (template.name || "") +
-      this.getItemPackageId(template) +
-      template.author +
-      (template.id || "") +
-      (template.description || "")
-    );
+		return `${template.tags || ""} \
+${!template.name && !template.id ? template.path || "" : ""} \
+${template.id || ""} \
+${template.name || ""} \
+${this.getItemPackageId(template)} \
+${template.author || ""} \
+${template.description || ""}`;
   }
 
   getItemPackageId(template: PromptTemplate): string {


### PR DESCRIPTION
Hello,

Here is a pull request to improve the template suggestions.

I noticed that with the query 'def', the search always returned all templates. This is due to the method `ExampleModal.getItemText()` where there are missing checks for `undefined`.
- I also added spaces to improve fuzzy search
- and sorted the text by order of priority of the metadata

I also noticed in the code that `getMetadata()` had a property `id` whereas `PromptTemplate` defines `promptId`, and in `ExampleModal` there is no mapping provided.
So I propose to align the property names on `promptId` to avoid confusion.

Let me know what you think?

warning:
As there are no unit tests, it is difficult to be sure of not having introduced a regression, but I have tried to be meticulous in the changes made and I do not think I have forgotten anything. No regression visible during testing on a dedicated vault.

PS:
I think there is still a lot of work to be done on the definition of a prompt in the code by writing a real business object `PromptTemplate` to centralize the code, especially for the concept of `packageId` and to initiate unit tests on it.