### PR TITLE
fix: syntax error in stream process of custom LLM provider

### DIFF
--- a/src/LLMProviders/custom/base.tsx
+++ b/src/LLMProviders/custom/base.tsx
@@ -68,8 +68,8 @@ if (res.status >= 300) {
   const err = data?.error?.message || JSON.stringify(data);
   throw err;
 }
-let resultText = "";
-const lines = chunk.split("\ndata: ");
+let resultTexts = [];
+const lines = this.chunk.split("\\ndata: ");
 
 const parsedLines = lines
     .map((line) => line.replace(/^data: /, "").trim()) // Remove the "data: " prefix
@@ -87,10 +87,10 @@ for (const parsedLine of parsedLines) {
     const { content } = delta;
     // Update the UI with the new content
     if (content) {
-        resultText += content;
+        resultTexts.push(content);
     }
 }
-return resultText;`,
+return resultTexts.join("");`,
   sanatization_response: `// catch error
 if (res.status >= 300) {
   const err = data?.error?.message || JSON.stringify(data);


### PR DESCRIPTION
The default script for `Stream Sanitization` is incorrectly interpreted, leading to a syntax error in the following code:

```javascript
const lines = chunk.split("
data: ");
```

Additionally, when the `runJSInSandbox` function is called, the `chunk` variable is filtered because it is neither a function nor an object.