### PR TITLE
fix try to find image files in the attachment folder based on the user's preferences

### DIFF
--- a/src/scope/context-manager.ts
+++ b/src/scope/context-manager.ts
@@ -40,7 +40,6 @@ import { convertArrayBufferToBase64Link } from "#/LLMProviders/utils";
 
 import mime from "mime-types"
 import { InputOptions } from "#/lib/models";
-import { c } from "tar";
 
 interface CodeBlock {
   type: string;


### PR DESCRIPTION
If the Text-Gen-Plugin is in "includeAttachmentsInRequest" mode, it should attempt to locate image files within the attachment folder, guided by the user's preferences.

Furthermore, a related submodule pull request is [Add InputOptions for Enabling Image Inputs in GPT-4o Models](https://github.com/text-gen/models/pull/2). 