### PR TITLE
README: Update/correct link to Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">obsidian-textgenerator-plugin</h1>
 
 <div align="center">
-  <a href="https://bit.ly/3ORwT00">Documentation</a>
+  <a href="https://bit.ly/tg_docs">Documentation</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>
   <a href="https://discord.gg/mEhvhkRfq5">Discord</a>
   <span>&nbsp;&nbsp;•&nbsp;&nbsp;</span>


### PR DESCRIPTION
Fixes #317

Update the link to Documentation in the `README.md` file.

* Change the link from `https://bit.ly/3ORwT00` to `https://bit.ly/tg_docs` to fix the 404 error.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nhaouari/obsidian-textgenerator-plugin/issues/317?shareId=6c338e4c-ad0b-436e-a1d0-22908b247c2d).