### PR TITLE
Add MiniMax provider support

### DIFF
--- a/src/LLMProviders/index.ts
+++ b/src/LLMProviders/index.ts
@@ -14,6 +14,7 @@ import LangchainChatGoogleGenerativeAIProvider from "./langchain/googleGenerativ
 import LangchainOpenAIAgentProvider from "./langchain/openaiAgent";
 import LangchainPerplexityChatProvider from "./langchain/perplexityChat";
 import LangchainTogetherChatProvider from "./langchain/togetherChat";
+import LangchainMiniMaxChatProvider from "./langchain/minimaxChat";
 // import LangchainReplicaProvider from "./langchain/replica"
 
 // import { LOCClone1, LOCClone2 } from "./langchain/clones";
@@ -45,6 +46,9 @@ export const defaultProviders = [
 
   // together ai
   LangchainTogetherChatProvider,
+
+  // minimax
+  LangchainMiniMaxChatProvider,
 
   // azure
   LangchainAzureOpenAIChatProvider,

--- a/src/LLMProviders/langchain/minimaxChat.tsx
+++ b/src/LLMProviders/langchain/minimaxChat.tsx
@@ -1,0 +1,154 @@
+import React from "react";
+import LangchainBase from "./base";
+import LLMProviderInterface, { LLMConfig } from "../interface";
+import { IconExternalLink } from "#/ui/icons";
+import { ModelsHandler, HeaderEditor } from "../utils";
+import debug from "debug";
+import { OpenAIChatInput } from "@langchain/openai";
+import { Input, SettingItem, useGlobal } from "../refs";
+
+const logger = debug("textgenerator:llmProvider:minimaxChat");
+
+const default_values = {
+  basePath: "https://api.minimax.io/v1",
+  model: "MiniMax-M3",
+};
+
+export default class LangchainMiniMaxChatProvider
+  extends LangchainBase
+  implements LLMProviderInterface
+{
+  static provider = "Langchain" as const;
+  static id = "MiniMax (Langchain)" as const;
+  static slug = "minimax" as const;
+  static displayName = "MiniMax";
+
+  streamable = true;
+
+  id = LangchainMiniMaxChatProvider.id;
+  provider = LangchainMiniMaxChatProvider.provider;
+  originalId = LangchainMiniMaxChatProvider.id;
+
+  default_values = default_values;
+
+  async load() {
+    const { ChatOpenAI } = await import("@langchain/openai");
+    this.llmClass = ChatOpenAI;
+  }
+
+  getConfig(options: LLMConfig): Partial<OpenAIChatInput> {
+    return this.cleanConfig({
+      apiKey: options.api_key,
+      openAIApiKey: options.api_key,
+
+      modelKwargs: options.modelKwargs,
+      modelName: options.model,
+      maxTokens: +options.max_tokens,
+      temperature: +options.temperature,
+      frequencyPenalty: +options.frequency_penalty || 0,
+      presencePenalty: +options.presence_penalty || 0,
+      n: options.n || 1,
+      stop: options.stop || undefined,
+      streaming: options.stream || false,
+      maxRetries: 3,
+      headers: options.headers || undefined,
+    } as Partial<OpenAIChatInput>);
+  }
+
+  RenderSettings(
+    props: Parameters<LLMProviderInterface["RenderSettings"]>[0]
+  ) {
+    const global = useGlobal();
+
+    const id = props.self.id;
+    const config = (global.plugin.settings.LLMProviderOptions[id] ??= {
+      ...default_values,
+    });
+
+    return (
+      <>
+        <SettingItem
+          name="API Key"
+          register={props.register}
+          sectionId={props.sectionId}
+        >
+          <Input
+            type="password"
+            value={config.api_key || ""}
+            setValue={async (value) => {
+              config.api_key = value;
+              global.triggerReload();
+              global.plugin.encryptAllKeys();
+              await global.plugin.saveSettings();
+            }}
+          />
+        </SettingItem>
+
+        <SettingItem
+          name="Base Path"
+          description="MiniMax OpenAI-compatible API endpoint"
+          register={props.register}
+          sectionId={props.sectionId}
+        >
+          <Input
+            value={config.basePath || default_values.basePath}
+            placeholder="Enter your API Base Path"
+            setValue={async (value) => {
+              config.basePath = value || default_values.basePath;
+              global.triggerReload();
+              await global.plugin.saveSettings();
+            }}
+          />
+        </SettingItem>
+
+        <ModelsHandler
+          register={props.register}
+          sectionId={props.sectionId}
+          llmProviderId={props.self.originalId || id}
+          default_values={default_values}
+          config={config}
+        />
+
+        <HeaderEditor
+          enabled={!!config.headers}
+          setEnabled={async (value) => {
+            if (!value) config.headers = undefined;
+            else config.headers = "{}";
+            global.triggerReload();
+            await global.plugin.saveSettings();
+          }}
+          headers={config.headers}
+          setHeaders={async (value) => {
+            config.headers = value;
+            global.triggerReload();
+            await global.plugin.saveSettings();
+          }}
+        />
+
+        <div className="plug-tg-flex plug-tg-flex-col plug-tg-gap-2">
+          <div className="plug-tg-text-lg plug-tg-opacity-70">Useful links</div>
+          <a href="https://platform.minimax.io/docs/api-reference/api-overview">
+            <SettingItem
+              name="API documentation"
+              className="plug-tg-text-xs plug-tg-opacity-50 hover:plug-tg-opacity-100"
+              register={props.register}
+              sectionId={props.sectionId}
+            >
+              <IconExternalLink />
+            </SettingItem>
+          </a>
+          <a href="https://platform.minimaxi.com/docs/api-reference/api-overview">
+            <SettingItem
+              name="API documentation (China)"
+              className="plug-tg-text-xs plug-tg-opacity-50 hover:plug-tg-opacity-100"
+              register={props.register}
+              sectionId={props.sectionId}
+            >
+              <IconExternalLink />
+            </SettingItem>
+          </a>
+        </div>
+      </>
+    );
+  }
+}

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -1171,6 +1171,13 @@ const AI_MODELS: Record<
     maxTokens: 228700,
     llm: ["Together AI (Langchain)"],
   },
+  "MiniMax-M3": {
+    encoding: "cl100k_base",
+    prices: { prompt: 0.0006, completion: 0.0024 },
+    maxTokens: 1000000,
+    llm: ["MiniMax (Langchain)"],
+    isThinking: true,
+  },
   "google/gemma-3n-E4B-it": {
     encoding: "cl100k_base",
     prices: { prompt: 0.00002, completion: 0.00004 },


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Adds a MiniMax OpenAI-compatible LangChain provider using the global API base URL.
- Registers MiniMax-M3 with the target 1,000,000 token context window and 0.6/2.4 per-million token pricing.
- Links both global and China MiniMax API documentation from provider settings.

## Checks
- git add -A -N && git diff HEAD secret scan
- npm install (failed: peer dependency conflict between handlebars and handlebars-async-helpers)
- npm install --legacy-peer-deps
- npm run build (failed: existing bundle resolution errors for node:child_process/node:readline from @anthropic-ai/sdk via @langchain/anthropic)