### PR TITLE
Add complete MiniMax provider support

### DIFF
--- a/src/LLMProviders/index.ts
+++ b/src/LLMProviders/index.ts
@@ -14,6 +14,9 @@ import LangchainChatGoogleGenerativeAIProvider from "./langchain/googleGenerativ
 import LangchainOpenAIAgentProvider from "./langchain/openaiAgent";
 import LangchainPerplexityChatProvider from "./langchain/perplexityChat";
 import LangchainTogetherChatProvider from "./langchain/togetherChat";
+import LangchainMiniMaxOpenAIProvider, {
+  LangchainMiniMaxAnthropicProvider,
+} from "./langchain/minimaxChat";
 // import LangchainReplicaProvider from "./langchain/replica"
 
 // import { LOCClone1, LOCClone2 } from "./langchain/clones";
@@ -45,6 +48,10 @@ export const defaultProviders = [
 
   // together ai
   LangchainTogetherChatProvider,
+
+  // minimax
+  LangchainMiniMaxOpenAIProvider,
+  LangchainMiniMaxAnthropicProvider,
 
   // azure
   LangchainAzureOpenAIChatProvider,

--- a/src/LLMProviders/interface.ts
+++ b/src/LLMProviders/interface.ts
@@ -87,4 +87,10 @@ export interface LLMConfig {
   reasoningEffort?: "low" | "medium" | "high";
   /** Manual override: treat this model as a thinking/reasoning model regardless of auto-detection */
   isThinkingModel?: boolean;
+  /** Thinking mode for models that support adaptive and disabled modes */
+  thinkingMode?: "adaptive" | "disabled";
+  /** Request admission tier for providers that support tier selection */
+  serviceTier?: "standard" | "priority";
+  /** Official API region selected in provider settings */
+  apiRegion?: "Global" | "China";
 }

--- a/src/LLMProviders/langchain/minimaxChat.tsx
+++ b/src/LLMProviders/langchain/minimaxChat.tsx
@@ -1,0 +1,357 @@
+import React from "react";
+import type { BaseLanguageModelParams } from "@langchain/core/language_models/base";
+import type { AnthropicInput } from "@langchain/anthropic";
+import type { OpenAIChatInput } from "@langchain/openai";
+
+import { IconExternalLink } from "#/ui/icons";
+import LangchainBase from "./base";
+import LLMProviderInterface, { LLMConfig } from "../interface";
+import { HeaderEditor, ModelsHandler } from "../utils";
+import { Dropdown, Input, Message, SettingItem, useGlobal } from "../refs";
+import {
+  calculateMiniMaxPrice,
+  getMiniMaxEndpoint,
+  getMiniMaxModelKwargs,
+  MINIMAX_DOCS,
+  MINIMAX_MODELS,
+  MiniMaxProtocol,
+  MiniMaxRegion,
+  MiniMaxServiceTier,
+  MiniMaxThinkingMode,
+  normalizeMiniMaxMessages,
+  wrapMiniMaxAnthropicFetch,
+} from "./minimaxConfig";
+
+const commonDefaultValues = {
+  apiRegion: "Global" as MiniMaxRegion,
+  model: MINIMAX_MODELS.m3,
+  thinkingMode: "adaptive" as const,
+  serviceTier: "standard" as const,
+};
+
+const openAIDefaultValues = {
+  ...commonDefaultValues,
+  basePath: getMiniMaxEndpoint("Global", "openai"),
+};
+
+const anthropicDefaultValues = {
+  ...commonDefaultValues,
+  basePath: getMiniMaxEndpoint("Global", "anthropic"),
+};
+
+type MiniMaxDefaultValues = {
+  apiRegion: MiniMaxRegion;
+  model: string;
+  thinkingMode: MiniMaxThinkingMode;
+  serviceTier: MiniMaxServiceTier;
+  basePath: string;
+};
+
+function MiniMaxSettings({
+  props,
+  protocol,
+  defaultValues,
+}: {
+  props: Parameters<LLMProviderInterface["RenderSettings"]>[0];
+  protocol: MiniMaxProtocol;
+  defaultValues: MiniMaxDefaultValues;
+}) {
+  const global = useGlobal();
+  const id = props.self.id;
+  const config = (global.plugin.settings.LLMProviderOptions[id] ??= {
+    ...defaultValues,
+  });
+  const isM3 = (config.model || defaultValues.model) === MINIMAX_MODELS.m3;
+
+  return (
+    <>
+      <SettingItem
+        name="API Key"
+        register={props.register}
+        sectionId={props.sectionId}
+      >
+        <Input
+          type="password"
+          value={config.api_key || ""}
+          setValue={async (value) => {
+            config.api_key = value;
+            global.triggerReload();
+            global.plugin.encryptAllKeys();
+            await global.plugin.saveSettings();
+          }}
+        />
+      </SettingItem>
+
+      <SettingItem
+        name="API Region"
+        register={props.register}
+        sectionId={props.sectionId}
+      >
+        <Dropdown
+          value={config.apiRegion || defaultValues.apiRegion}
+          values={["Global", "China"]}
+          setValue={async (value) => {
+            const region = value as MiniMaxRegion;
+            config.apiRegion = region;
+            config.basePath = getMiniMaxEndpoint(region, protocol);
+            global.triggerReload();
+            await global.plugin.saveSettings();
+          }}
+        />
+      </SettingItem>
+
+      <SettingItem
+        name="Base Path"
+        description={`${
+          protocol === "openai" ? "OpenAI" : "Anthropic"
+        }-compatible API endpoint`}
+        register={props.register}
+        sectionId={props.sectionId}
+      >
+        <Input
+          value={config.basePath || defaultValues.basePath}
+          placeholder="Enter your API Base Path"
+          setValue={async (value) => {
+            config.basePath = value || defaultValues.basePath;
+            global.triggerReload();
+            await global.plugin.saveSettings();
+          }}
+        />
+      </SettingItem>
+
+      <ModelsHandler
+        register={props.register}
+        sectionId={props.sectionId}
+        llmProviderId={props.self.originalId || id}
+        default_values={defaultValues}
+        config={config}
+      />
+
+      {isM3 && (
+        <>
+          <SettingItem
+            name="Thinking Mode"
+            register={props.register}
+            sectionId={props.sectionId}
+          >
+            <Dropdown
+              value={config.thinkingMode || defaultValues.thinkingMode}
+              values={["adaptive", "disabled"]}
+              setValue={async (value) => {
+                config.thinkingMode = value;
+                global.triggerReload();
+                await global.plugin.saveSettings();
+              }}
+            />
+          </SettingItem>
+
+          <SettingItem
+            name="Service Tier"
+            register={props.register}
+            sectionId={props.sectionId}
+          >
+            <Dropdown
+              value={config.serviceTier || defaultValues.serviceTier}
+              values={["standard", "priority"]}
+              setValue={async (value) => {
+                config.serviceTier = value;
+                global.triggerReload();
+                await global.plugin.saveSettings();
+              }}
+            />
+          </SettingItem>
+        </>
+      )}
+
+      <HeaderEditor
+        enabled={!!config.headers}
+        setEnabled={async (value) => {
+          config.headers = value ? "{}" : undefined;
+          global.triggerReload();
+          await global.plugin.saveSettings();
+        }}
+        headers={config.headers}
+        setHeaders={async (value) => {
+          config.headers = value;
+          global.triggerReload();
+          await global.plugin.saveSettings();
+        }}
+      />
+
+      <div className="plug-tg-flex plug-tg-flex-col plug-tg-gap-2">
+        <div className="plug-tg-text-lg plug-tg-opacity-70">Useful links</div>
+        {(["Global", "China"] as MiniMaxRegion[]).map((region) => (
+          <a key={region} href={MINIMAX_DOCS[region][protocol]}>
+            <SettingItem
+              name={`${region} API documentation`}
+              className="plug-tg-text-xs plug-tg-opacity-50 hover:plug-tg-opacity-100"
+              register={props.register}
+              sectionId={props.sectionId}
+            >
+              <IconExternalLink />
+            </SettingItem>
+          </a>
+        ))}
+      </div>
+    </>
+  );
+}
+
+abstract class LangchainMiniMaxBaseProvider extends LangchainBase {
+  abstract protocol: MiniMaxProtocol;
+  abstract default_values: MiniMaxDefaultValues;
+  abstract getConfig(options: LLMConfig): any;
+
+  RenderSettings(props: Parameters<LLMProviderInterface["RenderSettings"]>[0]) {
+    return (
+      <MiniMaxSettings
+        props={props}
+        protocol={this.protocol}
+        defaultValues={this.default_values}
+      />
+    );
+  }
+
+  generate(
+    messages: Message[],
+    reqParams: Partial<Omit<LLMConfig, "n">>,
+    onToken?: (
+      token: string,
+      first: boolean
+    ) => Promise<string | void | null | undefined>,
+    customConfig?: any
+  ) {
+    return super.generate(
+      normalizeMiniMaxMessages(messages, this.protocol),
+      reqParams,
+      onToken,
+      customConfig
+    );
+  }
+
+  generateMultiple(messages: Message[], reqParams: Partial<LLMConfig>) {
+    return super.generateMultiple(
+      normalizeMiniMaxMessages(messages, this.protocol),
+      reqParams
+    );
+  }
+
+  async calcPrice(tokens: number, reqParams: Partial<LLMConfig>) {
+    return calculateMiniMaxPrice(
+      tokens,
+      reqParams.max_tokens || 100,
+      reqParams.model || MINIMAX_MODELS.m3,
+      reqParams.serviceTier || "standard"
+    );
+  }
+}
+
+export default class LangchainMiniMaxOpenAIProvider
+  extends LangchainMiniMaxBaseProvider
+  implements LLMProviderInterface
+{
+  static provider = "Langchain" as const;
+  static id = "MiniMax OpenAI (Langchain)" as const;
+  static slug = "minimaxOpenAI" as const;
+  static displayName = "MiniMax OpenAI";
+
+  protocol = "openai" as const;
+  streamable = true;
+  id = LangchainMiniMaxOpenAIProvider.id;
+  provider = LangchainMiniMaxOpenAIProvider.provider;
+  originalId = LangchainMiniMaxOpenAIProvider.id;
+  default_values = openAIDefaultValues;
+
+  async load() {
+    const { ChatOpenAI } = await import("@langchain/openai");
+    this.llmClass = ChatOpenAI;
+  }
+
+  getConfig(options: LLMConfig): Partial<OpenAIChatInput> {
+    return this.cleanConfig({
+      apiKey: options.api_key,
+      openAIApiKey: options.api_key,
+      modelKwargs: getMiniMaxModelKwargs(
+        options.model,
+        options.thinkingMode,
+        options.serviceTier,
+        options.modelKwargs
+      ),
+      modelName: options.model,
+      maxTokens: +options.max_tokens,
+      temperature: +options.temperature,
+      frequencyPenalty: +options.frequency_penalty || 0,
+      presencePenalty: +options.presence_penalty || 0,
+      n: options.n || 1,
+      stop: options.stop || undefined,
+      streaming: options.stream || false,
+      maxRetries: 3,
+      headers: options.headers || undefined,
+    } as Partial<OpenAIChatInput>);
+  }
+}
+
+export class LangchainMiniMaxAnthropicProvider
+  extends LangchainMiniMaxBaseProvider
+  implements LLMProviderInterface
+{
+  static provider = "Langchain" as const;
+  static id = "MiniMax Anthropic (Langchain)" as const;
+  static slug = "minimaxAnthropic" as const;
+  static displayName = "MiniMax Anthropic";
+
+  protocol = "anthropic" as const;
+  streamable = true;
+  corsBypass = true;
+  id = LangchainMiniMaxAnthropicProvider.id;
+  provider = LangchainMiniMaxAnthropicProvider.provider;
+  originalId = LangchainMiniMaxAnthropicProvider.id;
+  default_values = anthropicDefaultValues;
+
+  async load() {
+    const { ChatAnthropic } = await import("@langchain/anthropic");
+    this.llmClass = class MiniMaxChatAnthropic extends ChatAnthropic {
+      constructor(fields: any) {
+        const { configuration = {}, ...rest } = fields;
+        const fetchImpl = configuration.fetch || globalThis.fetch;
+        super({
+          ...rest,
+          clientOptions: {
+            ...rest.clientOptions,
+            ...configuration,
+            fetch: wrapMiniMaxAnthropicFetch(fetchImpl),
+          },
+        });
+      }
+    };
+  }
+
+  getConfig(
+    options: LLMConfig
+  ): Partial<AnthropicInput & BaseLanguageModelParams> {
+    const modelKwargs = getMiniMaxModelKwargs(
+      options.model,
+      options.thinkingMode,
+      options.serviceTier,
+      options.modelKwargs
+    );
+    const { thinking, service_tier, ...invocationKwargs } = modelKwargs as any;
+
+    return this.cleanConfig({
+      anthropicApiKey: options.api_key,
+      anthropicApiUrl: options.basePath,
+      modelName: options.model,
+      maxTokens: options.max_tokens,
+      temperature:
+        thinking?.type === "adaptive" ? undefined : options.temperature,
+      stopSequences: options.stop,
+      streaming: options.stream,
+      maxRetries: 3,
+      thinking,
+      invocationKwargs: {
+        ...invocationKwargs,
+        ...(service_tier ? { service_tier } : {}),
+      },
+    } as any);
+  }
+}

--- a/src/LLMProviders/langchain/minimaxChat.tsx
+++ b/src/LLMProviders/langchain/minimaxChat.tsx
@@ -12,6 +12,7 @@ import {
   calculateMiniMaxPrice,
   getMiniMaxEndpoint,
   getMiniMaxModelKwargs,
+  MINIMAX_DEFAULT_THINKING_MODES,
   MINIMAX_DOCS,
   MINIMAX_MODELS,
   MiniMaxProtocol,
@@ -37,6 +38,7 @@ const openAIDefaultValues = {
 const anthropicDefaultValues = {
   ...commonDefaultValues,
   basePath: getMiniMaxEndpoint("Global", "anthropic"),
+  thinkingMode: MINIMAX_DEFAULT_THINKING_MODES.anthropic,
 };
 
 type MiniMaxDefaultValues = {

--- a/src/LLMProviders/langchain/minimaxConfig.test.ts
+++ b/src/LLMProviders/langchain/minimaxConfig.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from "vitest";
+
+import AI_MODELS from "../../lib/models";
+import {
+  calculateMiniMaxPrice,
+  getMiniMaxEndpoint,
+  getMiniMaxModelKwargs,
+  MINIMAX_MODELS,
+  MINIMAX_PRICING,
+  normalizeMiniMaxMessages,
+  rewriteMiniMaxAnthropicRequestBody,
+  wrapMiniMaxAnthropicFetch,
+} from "./minimaxConfig";
+
+describe("MiniMax provider configuration", () => {
+  it("exposes both protocols in both regions", () => {
+    expect(getMiniMaxEndpoint("Global", "openai")).toBe(
+      "https://api.minimax.io/v1"
+    );
+    expect(getMiniMaxEndpoint("China", "openai")).toBe(
+      "https://api.minimaxi.com/v1"
+    );
+    expect(getMiniMaxEndpoint("Global", "anthropic")).toBe(
+      "https://api.minimax.io/anthropic"
+    );
+    expect(getMiniMaxEndpoint("China", "anthropic")).toBe(
+      "https://api.minimaxi.com/anthropic"
+    );
+  });
+
+  it("applies configurable thinking and service tier only to M3", () => {
+    expect(
+      getMiniMaxModelKwargs(MINIMAX_MODELS.m3, "disabled", "priority")
+    ).toEqual({
+      thinking: { type: "disabled" },
+      service_tier: "priority",
+    });
+    expect(
+      getMiniMaxModelKwargs(MINIMAX_MODELS.m27, "disabled", "priority")
+    ).toEqual({});
+  });
+
+  it("uses the correct M3 pricing tier and M2.7 fixed pricing", () => {
+    expect(
+      calculateMiniMaxPrice(500_000, 1_000, MINIMAX_MODELS.m3, "standard")
+    ).toBeCloseTo(0.1512);
+    expect(
+      calculateMiniMaxPrice(600_000, 1_000, MINIMAX_MODELS.m3, "standard")
+    ).toBeCloseTo(0.3624);
+    expect(
+      calculateMiniMaxPrice(500_000, 1_000, MINIMAX_MODELS.m3, "priority")
+    ).toBeCloseTo(0.2268);
+    expect(
+      calculateMiniMaxPrice(600_000, 1_000, MINIMAX_MODELS.m3, "priority")
+    ).toBeCloseTo(0.5436);
+    expect(
+      calculateMiniMaxPrice(100_000, 1_000, MINIMAX_MODELS.m27)
+    ).toBeCloseTo(0.0312);
+  });
+
+  it("registers both target models with complete metadata", () => {
+    const m3 = AI_MODELS[MINIMAX_MODELS.m3];
+    const m27 = AI_MODELS[MINIMAX_MODELS.m27];
+
+    expect(m3).toMatchObject({
+      maxTokens: 1_000_000,
+      isThinking: true,
+      inputOptions: { images: true, videos: true },
+      llm: ["MiniMax OpenAI (Langchain)", "MiniMax Anthropic (Langchain)"],
+    });
+    expect(m3.priceTiers).toEqual([
+      ...MINIMAX_PRICING[MINIMAX_MODELS.m3].tiers,
+    ]);
+    expect(m27).toMatchObject({
+      maxTokens: 204_800,
+      isThinking: true,
+      prices: { prompt: 0.0003, completion: 0.0012 },
+      cachePrices: { read: 0.00006, write: 0.000375 },
+      llm: ["MiniMax OpenAI (Langchain)", "MiniMax Anthropic (Langchain)"],
+    });
+  });
+
+  it("preserves video input for each protocol request format", async () => {
+    const messages = [
+      {
+        role: "user" as const,
+        content: [
+          {
+            type: "image_url",
+            image_url: { url: "data:video/mp4;base64,AAAA" },
+          },
+        ],
+      },
+    ];
+
+    const openAIContent = normalizeMiniMaxMessages(messages, "openai")[0]
+      .content as any[];
+    expect(openAIContent[0]).toMatchObject({
+      type: "video_url",
+      video_url: { url: "data:video/mp4;base64,AAAA" },
+    });
+
+    const anthropicContent = normalizeMiniMaxMessages(messages, "anthropic")[0]
+      .content as any[];
+    const requestBody = rewriteMiniMaxAnthropicRequestBody(
+      JSON.stringify({ messages: [{ content: anthropicContent }] })
+    ) as string;
+    const parsedRequestBody = JSON.parse(requestBody) as any;
+    expect(parsedRequestBody.messages[0].content[0]).toEqual({
+      type: "video",
+      source: { type: "base64", media_type: "video/mp4", data: "AAAA" },
+    });
+
+    const fetchImpl = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response("{}")
+    );
+    await wrapMiniMaxAnthropicFetch(fetchImpl)("https://example.com", {
+      method: "POST",
+      body: JSON.stringify({ messages: [{ content: anthropicContent }] }),
+    });
+    const capturedBody = fetchImpl.mock.calls[0][1]?.body as string;
+    expect(JSON.parse(capturedBody) as any).toEqual({
+      messages: [
+        {
+          content: [
+            {
+              type: "video",
+              source: {
+                type: "base64",
+                media_type: "video/mp4",
+                data: "AAAA",
+              },
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it.each([
+    ["openai", "Global"],
+    ["openai", "China"],
+    ["anthropic", "Global"],
+    ["anthropic", "China"],
+  ] as const)(
+    "captures the %s SDK request for the %s region",
+    async (protocol, region) => {
+      const [{ ChatOpenAI }, { ChatAnthropic }] = await Promise.all([
+        import("@langchain/openai"),
+        import("@langchain/anthropic"),
+      ]);
+      let captured: { url: string; body: Record<string, any> } | undefined;
+      const captureFetch = async (
+        input: RequestInfo | URL,
+        init?: RequestInit
+      ) => {
+        captured = {
+          url: String(input),
+          body: JSON.parse(String(init?.body || "{}")) as Record<string, any>,
+        };
+        throw new Error("capture-complete");
+      };
+      const basePath = getMiniMaxEndpoint(region, protocol);
+      const modelKwargs = getMiniMaxModelKwargs(
+        MINIMAX_MODELS.m3,
+        "adaptive",
+        "standard"
+      ) as any;
+      const model =
+        protocol === "openai"
+          ? new ChatOpenAI({
+              apiKey: "test-key",
+              model: MINIMAX_MODELS.m3,
+              maxTokens: 8,
+              maxRetries: 0,
+              modelKwargs,
+              configuration: { baseURL: basePath, fetch: captureFetch },
+            })
+          : new ChatAnthropic({
+              apiKey: "test-key",
+              anthropicApiUrl: basePath,
+              model: MINIMAX_MODELS.m3,
+              maxTokens: 8,
+              maxRetries: 0,
+              thinking: modelKwargs.thinking,
+              invocationKwargs: {
+                service_tier: modelKwargs.service_tier,
+              },
+              clientOptions: { fetch: captureFetch },
+            });
+
+      try {
+        await model.invoke("Hello");
+      } catch {
+        expect(captured).toBeDefined();
+      }
+
+      const request = captured as {
+        url: string;
+        body: Record<string, any>;
+      };
+      expect(request.url).toBe(
+        protocol === "openai"
+          ? `${basePath}/chat/completions`
+          : `${basePath}/v1/messages`
+      );
+      expect(request.body).toMatchObject({
+        model: MINIMAX_MODELS.m3,
+        thinking: { type: "adaptive" },
+        service_tier: "standard",
+      });
+    }
+  );
+});

--- a/src/LLMProviders/langchain/minimaxConfig.test.ts
+++ b/src/LLMProviders/langchain/minimaxConfig.test.ts
@@ -5,6 +5,7 @@ import {
   calculateMiniMaxPrice,
   getMiniMaxEndpoint,
   getMiniMaxModelKwargs,
+  MINIMAX_DEFAULT_THINKING_MODES,
   MINIMAX_MODELS,
   MINIMAX_PRICING,
   normalizeMiniMaxMessages,
@@ -13,6 +14,10 @@ import {
 } from "./minimaxConfig";
 
 describe("MiniMax provider configuration", () => {
+  it("defaults Anthropic-compatible M3 requests to disabled thinking", () => {
+    expect(MINIMAX_DEFAULT_THINKING_MODES.anthropic).toBe("disabled");
+  });
+
   it("exposes both protocols in both regions", () => {
     expect(getMiniMaxEndpoint("Global", "openai")).toBe(
       "https://api.minimax.io/v1"

--- a/src/LLMProviders/langchain/minimaxConfig.ts
+++ b/src/LLMProviders/langchain/minimaxConfig.ts
@@ -1,0 +1,224 @@
+import type { Message } from "../../types";
+
+export const MINIMAX_MODELS = {
+  m3: "MiniMax-M3",
+  m27: "MiniMax-M2.7",
+} as const;
+
+export type MiniMaxModel = (typeof MINIMAX_MODELS)[keyof typeof MINIMAX_MODELS];
+export type MiniMaxProtocol = "openai" | "anthropic";
+export type MiniMaxRegion = "Global" | "China";
+export type MiniMaxServiceTier = "standard" | "priority";
+export type MiniMaxThinkingMode = "adaptive" | "disabled";
+
+export const MINIMAX_ENDPOINTS = {
+  Global: {
+    openai: "https://api.minimax.io/v1",
+    anthropic: "https://api.minimax.io/anthropic",
+  },
+  China: {
+    openai: "https://api.minimaxi.com/v1",
+    anthropic: "https://api.minimaxi.com/anthropic",
+  },
+} as const;
+
+export const MINIMAX_DOCS = {
+  Global: {
+    openai: "https://platform.minimax.io/docs/api-reference/text-openai-api",
+    anthropic:
+      "https://platform.minimax.io/docs/api-reference/text-anthropic-api",
+  },
+  China: {
+    openai: "https://platform.minimaxi.com/docs/api-reference/text-openai-api",
+    anthropic:
+      "https://platform.minimaxi.com/docs/api-reference/text-anthropic-api",
+  },
+} as const;
+
+const standardShortContextPrices = {
+  prompt: 0.0003,
+  completion: 0.0012,
+} as const;
+
+export const MINIMAX_PRICING = {
+  [MINIMAX_MODELS.m3]: {
+    contextWindow: 1_000_000,
+    tiers: [
+      {
+        serviceTier: "standard",
+        inputTokensLte: 512_000,
+        prices: standardShortContextPrices,
+        cachePrices: { read: 0.00006, write: null },
+      },
+      {
+        serviceTier: "standard",
+        inputTokensGt: 512_000,
+        prices: { prompt: 0.0006, completion: 0.0024 },
+        cachePrices: { read: 0.00012, write: null },
+      },
+      {
+        serviceTier: "priority",
+        inputTokensLte: 512_000,
+        prices: { prompt: 0.00045, completion: 0.0018 },
+        cachePrices: { read: 0.00009, write: null },
+      },
+      {
+        serviceTier: "priority",
+        inputTokensGt: 512_000,
+        prices: { prompt: 0.0009, completion: 0.0036 },
+        cachePrices: { read: 0.00018, write: null },
+      },
+    ],
+  },
+  [MINIMAX_MODELS.m27]: {
+    contextWindow: 204_800,
+    prices: standardShortContextPrices,
+    cachePrices: { read: 0.00006, write: 0.000375 },
+  },
+} as const;
+
+export function getMiniMaxEndpoint(
+  region: MiniMaxRegion,
+  protocol: MiniMaxProtocol
+) {
+  return MINIMAX_ENDPOINTS[region][protocol];
+}
+
+export function getMiniMaxModelKwargs(
+  model: string,
+  thinkingMode: MiniMaxThinkingMode = "adaptive",
+  serviceTier: MiniMaxServiceTier = "standard",
+  modelKwargs: Record<string, unknown> = {}
+) {
+  if (model !== MINIMAX_MODELS.m3) return modelKwargs;
+
+  return {
+    ...modelKwargs,
+    thinking: { type: thinkingMode },
+    service_tier: serviceTier,
+  };
+}
+
+export function calculateMiniMaxPrice(
+  inputTokens: number,
+  outputTokens: number,
+  model: string,
+  serviceTier: MiniMaxServiceTier = "standard"
+) {
+  if (model === MINIMAX_MODELS.m3) {
+    const tier = MINIMAX_PRICING[MINIMAX_MODELS.m3].tiers.find(
+      (candidate) =>
+        candidate.serviceTier === serviceTier &&
+        ("inputTokensLte" in candidate
+          ? inputTokens <= candidate.inputTokensLte
+          : inputTokens > candidate.inputTokensGt)
+    );
+    if (!tier) return 0;
+
+    return (
+      (inputTokens * tier.prices.prompt +
+        outputTokens * tier.prices.completion) /
+      1000
+    );
+  }
+
+  if (model !== MINIMAX_MODELS.m27) return 0;
+
+  const prices = MINIMAX_PRICING[MINIMAX_MODELS.m27].prices;
+  return (
+    (inputTokens * prices.prompt + outputTokens * prices.completion) / 1000
+  );
+}
+
+type ContentPart = Record<string, any>;
+
+function getMediaUrl(part: ContentPart) {
+  if (part.type !== "image_url") return undefined;
+  if (typeof part.image_url === "string") return part.image_url;
+  return part.image_url?.url as string | undefined;
+}
+
+function isVideoUrl(url: string) {
+  return (
+    url.startsWith("data:video/") ||
+    url.startsWith("mm_file://") ||
+    /\.(mp4|avi|mov|mkv)(?:[?#]|$)/i.test(url)
+  );
+}
+
+function getAnthropicVideoSource(url: string) {
+  const dataUrl = url.match(/^data:(video\/[^;,]+);base64,(.+)$/s);
+  if (dataUrl) {
+    return {
+      type: "base64",
+      media_type: dataUrl[1],
+      data: dataUrl[2],
+    };
+  }
+
+  return { type: "url", url };
+}
+
+export function normalizeMiniMaxMessages(
+  messages: Message[],
+  protocol: MiniMaxProtocol
+) {
+  return messages.map((message) => {
+    if (!Array.isArray(message.content)) return message;
+
+    const content = message.content.map((part: ContentPart) => {
+      const url = getMediaUrl(part);
+      if (!url || !isVideoUrl(url)) return part;
+
+      if (protocol === "openai") {
+        const { image_url, ...rest } = part;
+        return {
+          ...rest,
+          type: "video_url",
+          video_url:
+            typeof image_url === "string" ? { url: image_url } : image_url,
+        };
+      }
+
+      return {
+        type: "container_upload",
+        minimax_video_source: getAnthropicVideoSource(url),
+      };
+    });
+
+    return { ...message, content } as Message;
+  });
+}
+
+export function rewriteMiniMaxAnthropicRequestBody(
+  body: BodyInit | null | undefined
+) {
+  if (typeof body !== "string") return body;
+
+  let payload: any;
+  try {
+    payload = JSON.parse(body);
+  } catch {
+    return body;
+  }
+
+  for (const message of payload.messages ?? []) {
+    if (!Array.isArray(message.content)) continue;
+    message.content = message.content.map((part: ContentPart) => {
+      if (part.type !== "container_upload" || !part.minimax_video_source) {
+        return part;
+      }
+      return { type: "video", source: part.minimax_video_source };
+    });
+  }
+
+  return JSON.stringify(payload);
+}
+
+export function wrapMiniMaxAnthropicFetch(fetchImpl: typeof fetch) {
+  return (input: RequestInfo | URL, init?: RequestInit) =>
+    fetchImpl(input, {
+      ...init,
+      body: rewriteMiniMaxAnthropicRequestBody(init?.body),
+    });
+}

--- a/src/LLMProviders/langchain/minimaxConfig.ts
+++ b/src/LLMProviders/langchain/minimaxConfig.ts
@@ -11,6 +11,11 @@ export type MiniMaxRegion = "Global" | "China";
 export type MiniMaxServiceTier = "standard" | "priority";
 export type MiniMaxThinkingMode = "adaptive" | "disabled";
 
+export const MINIMAX_DEFAULT_THINKING_MODES = {
+  openai: "adaptive",
+  anthropic: "disabled",
+} as const;
+
 export const MINIMAX_ENDPOINTS = {
   Global: {
     openai: "https://api.minimax.io/v1",

--- a/src/LLMProviders/utils.tsx
+++ b/src/LLMProviders/utils.tsx
@@ -128,7 +128,10 @@ export function ModelsHandler(props: {
   }, []);
 
   const modelName = "" + config.model as string;
-  const model = (AI_MODELS as AI_MODELS_Type)[modelName.toLowerCase()] || (AI_MODELS as AI_MODELS_Type)["models" + modelName.toLowerCase()];
+  const model =
+    (AI_MODELS as AI_MODELS_Type)[modelName] ||
+    (AI_MODELS as AI_MODELS_Type)[modelName.toLowerCase()] ||
+    (AI_MODELS as AI_MODELS_Type)["models" + modelName.toLowerCase()];
 
   const supportedInputs = Object.keys(model?.inputOptions || {}).filter(e => !!e);
   return (
@@ -332,4 +335,3 @@ export function HeaderEditor({
     </div>
   );
 }
-

--- a/src/lib/models/index.ts
+++ b/src/lib/models/index.ts
@@ -1,4 +1,8 @@
 import type { LLMProviderType } from "../types";
+import {
+  MINIMAX_MODELS,
+  MINIMAX_PRICING,
+} from "#/LLMProviders/langchain/minimaxConfig";
 
 export type ModelType = {
   encoding: string;
@@ -6,6 +10,23 @@ export type ModelType = {
     prompt: number;
     completion: number;
   };
+  cachePrices?: {
+    read: number;
+    write: number | null;
+  };
+  priceTiers?: {
+    serviceTier: "standard" | "priority";
+    inputTokensLte?: number;
+    inputTokensGt?: number;
+    prices: {
+      prompt: number;
+      completion: number;
+    };
+    cachePrices: {
+      read: number;
+      write: number | null;
+    };
+  }[];
   maxTokens: number;
   llm: LLMProviderType[];
   order?: number;
@@ -1170,6 +1191,24 @@ const AI_MODELS: Record<
     prices: { prompt: 0.0003, completion: 0.0012 },
     maxTokens: 228700,
     llm: ["Together AI (Langchain)"],
+  },
+  [MINIMAX_MODELS.m3]: {
+    encoding: "cl100k_base",
+    prices: MINIMAX_PRICING[MINIMAX_MODELS.m3].tiers[0].prices,
+    cachePrices: MINIMAX_PRICING[MINIMAX_MODELS.m3].tiers[0].cachePrices,
+    priceTiers: [...MINIMAX_PRICING[MINIMAX_MODELS.m3].tiers],
+    maxTokens: MINIMAX_PRICING[MINIMAX_MODELS.m3].contextWindow,
+    llm: ["MiniMax OpenAI (Langchain)", "MiniMax Anthropic (Langchain)"],
+    isThinking: true,
+    inputOptions: { images: true, videos: true },
+  },
+  [MINIMAX_MODELS.m27]: {
+    encoding: "cl100k_base",
+    prices: MINIMAX_PRICING[MINIMAX_MODELS.m27].prices,
+    cachePrices: MINIMAX_PRICING[MINIMAX_MODELS.m27].cachePrices,
+    maxTokens: MINIMAX_PRICING[MINIMAX_MODELS.m27].contextWindow,
+    llm: ["MiniMax OpenAI (Langchain)", "MiniMax Anthropic (Langchain)"],
+    isThinking: true,
   },
   "google/gemma-3n-E4B-it": {
     encoding: "cl100k_base",

--- a/src/utils/api-request-formatter.ts
+++ b/src/utils/api-request-formatter.ts
@@ -75,7 +75,15 @@ export default class ReqFormatter {
     if (!this.plugin.textGenerator.LLMProvider) throw "LLM Provider not intialized";
 
     if (params.includeAttachmentsInRequest ?? params.advancedOptions?.includeAttachmentsInRequest)
-      params.prompt = await this.plugin.contextManager.splitContent(params.prompt, params.noteFile, (AI_MODELS[params.model?.toLowerCase()] || AI_MODELS["models/" + params.model?.toLowerCase()])?.inputOptions || {})
+      params.prompt = await this.plugin.contextManager.splitContent(
+        params.prompt,
+        params.noteFile,
+        (
+          (params.model && AI_MODELS[params.model]) ||
+          AI_MODELS[params.model?.toLowerCase()] ||
+          AI_MODELS["models/" + params.model?.toLowerCase()]
+        )?.inputOptions || {}
+      );
 
     let bodyParams: Partial<LLMConfig & { prompt: string }> & {
       messages: Message[];


### PR DESCRIPTION
## Summary
- Adds dedicated MiniMax OpenAI-compatible and Anthropic-compatible LangChain providers.
- Supports the global and China API regions, MiniMax-M3 and MiniMax-M2.7, configurable M3 thinking and service tiers, and M3 image/video input.
- Preserves the official per-model context windows, cache prices, and all M3 standard/priority pricing tiers.
- Uses protocol-specific M3 thinking defaults: adaptive for OpenAI-compatible requests and disabled for Anthropic-compatible requests.

## Checks
- `npm test -- --run` (24 tests passed)
- `npm test -- --run src/LLMProviders/langchain/minimaxConfig.test.ts` (10 tests passed)
- `npx prettier --check src/LLMProviders/langchain/minimaxChat.tsx src/LLMProviders/langchain/minimaxConfig.ts src/LLMProviders/langchain/minimaxConfig.test.ts`
- `npx tsc --noEmit` remains blocked by existing repository and dependency errors outside the MiniMax changes.
- `npm run build` remains blocked by the existing browser bundle resolution of Node built-ins from the current SDK dependency.
