### PR TITLE
Add Dependabot for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Adds `.github/dependabot.yml` to enable automated dependency updates.

**What this does:**
- Enables Dependabot for both `npm` and `github-actions` ecosystems
- Weekly check schedule (balances staying current vs. PR noise)
- Groups all updates per ecosystem into a single PR (avoids one-PR-per-dependency churn)

**Why:**
The repository has 50+ npm production dependencies and several GitHub Actions workflows with no automated update mechanism. Dependabot will surface security patches and version bumps automatically, reducing manual maintenance overhead.

---

This change was generated by [Autar](https://autar.ai) and reviewed by a human before submission.
